### PR TITLE
Update channel funding and improve channel retrieval logic

### DIFF
--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -8,6 +8,9 @@ jobs:
   test:
     environment: testnet
     runs-on: ubuntu-latest
+    concurrency: 
+      group: ${{ github.workflow }}-testnet
+      cancel-in-progress: false
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -111,11 +111,12 @@ jobs:
     - run: bun start
     
     - name: Open channel to a testnet node FTN004
+      run: bun run script/open-channel.ts --peer_id QmVxgZrgZESD5U3m2cq8qXpsGPXubERvZs3eXy9fpFeVtE
+    - name: Open channel to public testnet nodes in https://github.com/nervosnetwork/fiber/blob/develop/docs/testnet-nodes.md
       run: |
-        bun run script/open-channel.ts \
-          --peer_id QmVxgZrgZESD5U3m2cq8qXpsGPXubERvZs3eXy9fpFeVtE --funding_amount 0x3BFA28100
-        bun run script/open-channel.ts \
-          --peer_id QmVxgZrgZESD5U3m2cq8qXpsGPXubERvZs3eXy9fpFeVtE
+        bun run script/open-channel.ts --peer_id QmXen3eUHhywmutEzydCsW4hXBoeVmdET2FJvMX69XJ1Eo
+        bun run script/open-channel.ts --peer_id QmbKyzq9qUmymW2Gi8Zq7kKVpPiNA1XUJ6uMvsUC4F3p89
+
     - name: Close all channels
       run: bun run script/close-all-channels.ts
 

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -112,7 +112,10 @@ jobs:
     
     - name: Open channel to a testnet node FTN004
       run: |
-        bun run script/open-channel.ts --peer_id QmVxgZrgZESD5U3m2cq8qXpsGPXubERvZs3eXy9fpFeVtE
+        bun run script/open-channel.ts \
+          --peer_id QmVxgZrgZESD5U3m2cq8qXpsGPXubERvZs3eXy9fpFeVtE --funding_amount 0x3BFA28100
+        bun run script/open-channel.ts \
+          --peer_id QmVxgZrgZESD5U3m2cq8qXpsGPXubERvZs3eXy9fpFeVtE
     - name: Close all channels
       run: bun run script/close-all-channels.ts
 

--- a/.github/workflows/test-compose.yml
+++ b/.github/workflows/test-compose.yml
@@ -118,6 +118,7 @@ jobs:
         bun run script/open-channel.ts --peer_id QmbKyzq9qUmymW2Gi8Zq7kKVpPiNA1XUJ6uMvsUC4F3p89
 
     - name: Close all channels
+      if: always()
       run: bun run script/close-all-channels.ts
 
     - name: Monitor memory usage

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,7 +36,7 @@ services:
     command: [
       "fnn",
       # node name to be announced to fiber network [env: FIBER_ANNOUNCED_NODE_NAME]
-      "--fiber-announced-node-name", "FTN002",
+      "--fiber-announced-node-name", "FTN005",
       # addresses to be announced to fiber network [env: FIBER_ANNOUNCED_ADDRS=]
       # TODO: "--fiber-announced-addrs", "58228"
     ]

--- a/script/open-channel.ts
+++ b/script/open-channel.ts
@@ -13,6 +13,11 @@ const { values } = parseArgs({
       type: "string",
       short: "p",
     },
+    funding_amount: {
+      type: "string",
+      short: "a",
+      default: "0x3C5986200" // Default 16200000000 shannons
+    },
   },
   strict: true,
   allowPositionals: true,
@@ -25,9 +30,8 @@ if (!values.peer_id) {
 
 const channelParams = {
   peer_id: values.peer_id,
-  funding_amount: "0x174876E808", // 1000.00000008 CKB
+  funding_amount: values.funding_amount, // Use the provided funding amount or default
 };
-
 const rpc = new FiberRPC(FIBER_RPC_URL);
 
 // open channel

--- a/script/open-channel.ts
+++ b/script/open-channel.ts
@@ -1,6 +1,6 @@
 import { sleep } from "bun";
 import { parseArgs } from "util";
-import { getLatestChannel } from "../src/channel";
+import { getNewChannel } from "../src/channel";
 import { FIBER_RPC_URL } from "../src/common/constants";
 import { FiberRPC } from "../src/rpc/client";
 
@@ -48,7 +48,7 @@ while (Date.now() - startTime < 300 * 1000) {
   console.log("Waiting for channel to be ready...");
   await sleep(5000);
 
-  const channel = await getLatestChannel(rpc, values.peer_id);
+  const channel = await getNewChannel(rpc, values.peer_id);
   if (!channel) continue;
 
   console.debug("The funding channel:", channel);

--- a/src/channel.ts
+++ b/src/channel.ts
@@ -1,7 +1,6 @@
 
 import type { Channel } from "fiber";
 import { FiberRPC } from "./rpc/client";
-import { debug } from "console";
 
 /**
  * Retrieves the status of a specific channel for a given peer.
@@ -28,7 +27,7 @@ export async function getChannelStatus(rpc: FiberRPC, channelId: string, peerId?
  * @param peerId - The unique identifier of the peer
  * @returns The most recently created channel, or undefined if no channels exist
  */
-export async function getLatestChannel(rpc: FiberRPC, peerId: string) {
+export async function getNewChannel(rpc: FiberRPC, peerId: string) {
   const channels: Channel[] = await rpc.listChannels({
     peer_id: peerId,
     include_closed: true,
@@ -41,5 +40,10 @@ export async function getLatestChannel(rpc: FiberRPC, peerId: string) {
   const latestChannel = channels.reduce((latest, channel) => {
     return BigInt(channel.created_at) > BigInt(latest.created_at) ? channel : latest;
   }, channels[0]);
+
+  if (latestChannel.state.state_name === 'CHANNEL_READY') {
+    return undefined;
+  }
+
   return latestChannel;
 }

--- a/src/rpc/__tests__/channel.test.ts
+++ b/src/rpc/__tests__/channel.test.ts
@@ -1,5 +1,5 @@
 import { beforeAll, describe, expect, it, mock } from "bun:test";
-import { getLatestChannel } from "../../channel";
+import { getNewChannel } from "../../channel";
 import { FIBER_RPC_URL } from "../../common/constants";
 import { FiberRPC } from "../client";
 
@@ -54,7 +54,7 @@ describe("Channel", () => {
         }
       ])
     } as unknown as FiberRPC;
-    const channel = await getLatestChannel(mockRpc, "peer1");
+    const channel = await getNewChannel(mockRpc, "peer1");
     expect(channel?.channel_id).toEqual("0x20f4057f1e86f2e3df02b7a2fe168a45c3e24b149e9f6888fe41ccb5a99b5d6c");
   });
 
@@ -63,7 +63,7 @@ describe("Channel", () => {
       listChannels: mock(async () => [])
     } as unknown as FiberRPC;
 
-    const channel = await getLatestChannel(mockRpc, "peer1");
+    const channel = await getNewChannel(mockRpc, "peer1");
     expect(channel).toBeUndefined();
   });
 
@@ -74,6 +74,6 @@ describe("Channel", () => {
       })
     } as unknown as FiberRPC;
 
-    await expect(getLatestChannel(mockRpc, "peer1")).rejects.toThrow("RPC Failed");
+    await expect(getNewChannel(mockRpc, "peer1")).rejects.toThrow("RPC Failed");
   });
 });


### PR DESCRIPTION
Adjust the funding amount in the open-channel script and ensure the retrieval of new channels returns undefined for ready channels.

Additionally, add tests for opening channels to public testnet nodes.